### PR TITLE
MW-12118: Forward error labels as OpsGenie alert tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "error-sync-lib",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": "true",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",

--- a/src/__tests__/providers/OpsGenieAlertProvider.test.ts
+++ b/src/__tests__/providers/OpsGenieAlertProvider.test.ts
@@ -1,0 +1,146 @@
+import { OpsGenieAlertProvider, OpsGenieAlertProviderConfig } from '../../providers/OpsGenieAlertProvider';
+import { ErrorGroup, ErrorPriority, ErrorType, ErrorCountType } from '../../models';
+import opsGenie from 'opsgenie-sdk';
+
+// Mock the opsgenie-sdk
+jest.mock('opsgenie-sdk', () => ({
+  configure: jest.fn(),
+  alertV2: {
+    create: jest.fn(),
+    get: jest.fn(),
+    close: jest.fn(),
+  },
+}));
+
+describe('OpsGenieAlertProvider', () => {
+  const config: OpsGenieAlertProviderConfig = {
+    host: 'api.opsgenie.com',
+    apiKey: 'test-api-key',
+  };
+
+  let provider: OpsGenieAlertProvider;
+  const mockCreate = (opsGenie as any).alertV2.create as jest.Mock;
+  const mockGet = (opsGenie as any).alertV2.get as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    provider = new OpsGenieAlertProvider(config);
+  });
+
+  const makeErrorGroup = (labels?: string[]): ErrorGroup => ({
+    name: 'minware.com failed synthetic check',
+    sourceName: 'new-relic-synthetic-main-app',
+    type: ErrorType.DATA,
+    priority: ErrorPriority.P1,
+    priorityReason: 'test',
+    clientId: 'abc123',
+    count: 1,
+    countType: ErrorCountType.TRX,
+    mixpanelIds: [],
+    countPeriodHours: 1,
+    ticket: { url: 'https://example.atlassian.net/browse/MW-1' } as any,
+    alert: null as any,
+    instances: [{
+      name: 'minware.com failed synthetic check',
+      type: ErrorType.DATA,
+      count: 1,
+      countType: ErrorCountType.TRX,
+      countPeriodHours: 1,
+      ...(labels ? { labels } : {}),
+    } as any],
+    userEmails: [],
+  });
+
+  describe('generateAlertContent', () => {
+    it('should populate labels from the first error instance', async () => {
+      const errorGroup = makeErrorGroup(['synthetic', 'monitoring', 'minware-app']);
+
+      const content = await provider.generateAlertContent(errorGroup);
+
+      expect(content.labels).toEqual(['synthetic', 'monitoring', 'minware-app']);
+    });
+
+    it('should default to an empty label array when the error has no labels', async () => {
+      const errorGroup = makeErrorGroup(undefined);
+
+      const content = await provider.generateAlertContent(errorGroup);
+
+      expect(content.labels).toEqual([]);
+    });
+  });
+
+  describe('createAlert', () => {
+    it('should send labels as OpsGenie tags', async () => {
+      mockCreate.mockImplementation((_payload: any, cb: any) => cb(null, { data: {} }));
+
+      await provider.createAlert({
+        clientId: 'abc123',
+        summary: '[data] [src] failed synthetic check',
+        description: 'failed synthetic check',
+        priority: 'P1',
+        labels: ['synthetic', 'monitoring'],
+        ticketUrl: 'https://example.atlassian.net/browse/MW-1',
+        status: 'open',
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ['synthetic', 'monitoring'] }),
+        expect.any(Function),
+      );
+    });
+
+    it('should send an empty tags array when there are no labels', async () => {
+      mockCreate.mockImplementation((_payload: any, cb: any) => cb(null, { data: {} }));
+
+      await provider.createAlert({
+        clientId: 'abc123',
+        summary: 'summary',
+        description: 'desc',
+        priority: 'P1',
+        labels: [],
+        ticketUrl: undefined,
+        status: 'open',
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: [] }),
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('findAlert', () => {
+    it('should map OpsGenie tags back into labels', async () => {
+      mockGet.mockImplementation((_params: any, cb: any) => cb(null, {
+        data: {
+          message: 'summary',
+          description: 'desc',
+          priority: 'P1',
+          tags: ['synthetic', 'monitoring'],
+          details: { 'Ticket Link': 'https://example.atlassian.net/browse/MW-1' },
+          status: 'open',
+        },
+      }));
+
+      const alert = await provider.findAlert('abc123');
+
+      expect(alert?.labels).toEqual(['synthetic', 'monitoring']);
+    });
+
+    it('should default to an empty label array when the alert has no tags', async () => {
+      mockGet.mockImplementation((_params: any, cb: any) => cb(null, {
+        data: {
+          message: 'summary',
+          description: 'desc',
+          priority: 'P1',
+          details: { 'Ticket Link': undefined },
+          status: 'open',
+        },
+      }));
+
+      const alert = await provider.findAlert('abc123');
+
+      expect(alert?.labels).toEqual([]);
+    });
+  });
+});

--- a/src/models/Error.ts
+++ b/src/models/Error.ts
@@ -32,6 +32,7 @@ export type Error = {
   debugUrl?: string,
   debugMessage?: string,
   ticketType?: string,
+  labels?: string[],
 };
 
 export type ErrorGroup = {

--- a/src/providers/OpsGenieAlertProvider.ts
+++ b/src/providers/OpsGenieAlertProvider.ts
@@ -57,7 +57,7 @@ export class OpsGenieAlertProvider implements AlertProviderInterface {
         summary: opsgenieAlert.message,
         description: opsgenieAlert.description,
         priority: opsgenieAlert.priority,
-        labels: [],
+        labels: opsgenieAlert.tags ?? [],
         ticketUrl: opsgenieAlert.details['Ticket Link'],
         status: opsgenieAlert.status,
       }
@@ -73,6 +73,7 @@ export class OpsGenieAlertProvider implements AlertProviderInterface {
         description: alertContent.description,
         alias: alertContent.clientId,
         priority: priority,
+        tags: alertContent.labels,
         details: {
           'Ticket Link': alertContent.ticketUrl,
         },
@@ -113,7 +114,7 @@ export class OpsGenieAlertProvider implements AlertProviderInterface {
       summary,
       description: errorGroup.name,
       priority: this.config.priorityMap[errorGroup.priority],
-      labels: [],
+      labels: errorGroup.instances[0]?.labels ?? [],
       ticketUrl: errorGroup.ticket?.url,
       status: 'open',
     }


### PR DESCRIPTION
## Summary

OpsGenie alerts were created without tags, so error `labels` (e.g. `trigger-page`, `synthetic`) never reached OpsGenie and couldn't be used in notification rules. This wires error labels through to OpsGenie as **tags**, enabling tag-based paging rules for the emergency on-call work (MW-12118).

## Changes

- `models/Error.ts` — add optional `labels?: string[]` to the base `Error` type so labels flow through `ErrorGroup.instances`.
- `providers/OpsGenieAlertProvider.ts`:
  - `createAlert` sends `tags: alertContent.labels`.
  - `generateAlertContent` populates `labels` from `errorGroup.instances[0]?.labels ?? []`.
  - `findAlert` maps `opsgenieAlert.tags ?? []` back into `labels`.
- `package.json` — bump version `0.3.2` → `0.3.3`.
- New `__tests__/providers/OpsGenieAlertProvider.test.ts` (6 tests).

## Does this affect duplicate detection?

No.
- OpsGenie de-dupes on the **alias** (`clientId`), which is unchanged.
- `Synchronizer.doesAlertNeedUpdate` compares `summary`, `description`, and `ticketUrl` — **not** `labels` — so tags don't trigger spurious alert recreation / re-paging.

One nuance: alerts created before this ships won't retroactively gain tags (the update path ignores labels); they get tags only when next recreated. New alerts get tags immediately.

## Testing

- New OpsGenie provider suite: 6/6 passing.
- `lint:types` clean.
- Pre-existing failures in `NewRelicBrowserErrorProvider` (uniqueCount) and `Synchronizer` (jira.js/mime ESM parse) are unrelated — verified identical on the pristine tree.

## Follow-up (consumer side)

After this merges, tag `v0.3.3` and bump the pin in `error-sync` (`error-sync-lib#v0.3.2` → `#v0.3.3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)